### PR TITLE
mingw: allow cross building MK for win64

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 Formulae that you can install using this tap:
 
-- `libndt`: header-only C++11 library for running ndt5/ndt7 tests
+- `libndt`: header-only C++11 library for running ndt5/ndt7 tests;
 
-- `measurement-kit`: Measurement Kit binary, libraries and headers
+- `measurement-kit`: Measurement Kit binary, libraries and headers;
+
+- `mingw-w64-<package>`: cross build of package using brew's
+default `mingw-w64` package suitable for being included in the
+binary distrbution of OONI for Windows systems.
 
 ## Build and install instructions
 

--- a/measurement-kit.rb
+++ b/measurement-kit.rb
@@ -6,7 +6,9 @@ class MeasurementKit < Formula
   sha256 "04bc1832fbaa54a9fde4923e8f44a2f99610a862c228dd05977c36f54870d80f"
 
   depends_on "libevent"
-  depends_on "geoip"
+  depends_on "libmaxminddb"
+  depends_on "curl"
+
   depends_on "git" => :build
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -18,7 +20,7 @@ class MeasurementKit < Formula
   end
 
   def install
-    system "./autogen.sh"
+    system "./autogen.sh", "-n"
     system "./configure", "--prefix=#{prefix}", "--enable-shared"
     system "make", "V=0"
     system "make", "V=0", "install"

--- a/mingw-w64-curl.rb
+++ b/mingw-w64-curl.rb
@@ -1,0 +1,66 @@
+class MingwW64Curl < Formula
+  desc "Get a file from an HTTP, HTTPS or FTP server"
+  homepage "https://curl.haxx.se/"
+  url "https://curl.haxx.se/download/curl-7.64.1.tar.bz2"
+  sha256 "4cc7c738b35250d0680f29e93e0820c4cb40035f43514ea3ec8d60322d41a45d"
+
+  keg_only :provided_by_macos  # Not very accurate
+
+  depends_on "pkg-config" => :build
+  depends_on "mingw-w64" => :build
+  depends_on "mingw-w64-libressl"
+
+  def install
+
+    ENV['AR'] = 'x86_64-w64-mingw32-ar'
+    ENV['AS'] = 'x86_64-w64-mingw32-as'
+    ENV['CC'] = 'x86_64-w64-mingw32-gcc'
+    ENV['CFLAGS'] = '-Wall -O2'
+    ENV['CPP'] = 'x86_64-w64-mingw32-cpp'
+    ENV['CXX'] = 'x86_64-w64-mingw32-g++'
+    ENV['CXXFLAGS'] = '-Wall -O2'
+    ENV['LD'] = 'x86_64-w64-mingw32-ld'
+    ENV['NM'] = 'x86_64-w64-mingw32-nm'
+    ENV['PATH'] = '/usr/local/bin:/usr/bin:/bin'
+    ENV['RANLIB'] = 'x86_64-w64-mingw32-ranlib'
+    ENV['STRIP'] = 'x86_64-w64-mingw32-strip'
+
+    args = %W[
+      --disable-debug
+      --host=x86_64-w64-mingw32
+      --disable-dependency-tracking
+      --disable-shared
+      --disable-tests
+      --prefix=#{prefix}
+      --without-ca-bundle
+      --without-ca-path
+      --disable-ftp
+      --disable-file
+      --disable-ldap
+      --disable-ldaps
+      --disable-rtsp
+      --disable-dict
+      --disable-telnet
+      --disable-tftp
+      --disable-pop3
+      --disable-imap
+      --disable-smb
+      --disable-smtp
+      --disable-gopher
+      --disable-manual
+      --enable-ipv6
+      --disable-sspi
+      --disable-ntlm-wb
+      --disable-tls-srp
+      --with-pic=yes
+      --without-libidn2
+      --without-zlib
+      --disable-rt
+      --disable-threaded-resolver
+      --with-ssl=/usr/local/opt/mingw-w64-libressl
+    ]
+
+    system "./configure", *args
+    system "make", "install"
+  end
+end

--- a/mingw-w64-libevent.rb
+++ b/mingw-w64-libevent.rb
@@ -1,0 +1,139 @@
+class MingwW64Libevent < Formula
+  desc "Asynchronous event library"
+  homepage "https://libevent.org/"
+  url "https://github.com/libevent/libevent/archive/release-2.1.8-stable.tar.gz"
+  sha256 "316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "mingw-w64-libressl"
+
+  keg_only :provided_by_macos  # Not very accurate
+
+  patch :DATA
+
+  def install
+
+    ENV['AR'] = 'x86_64-w64-mingw32-ar'
+    ENV['AS'] = 'x86_64-w64-mingw32-as'
+    ENV['CC'] = 'x86_64-w64-mingw32-gcc'
+    ENV['CPPFLAGS'] = '-I/usr/local/opt/mingw-w64-libressl/include -Wno-cpp'
+    ENV['CFLAGS'] = '-Wall -O2'
+    ENV['CPP'] = 'x86_64-w64-mingw32-cpp'
+    ENV['CXX'] = 'x86_64-w64-mingw32-g++'
+    ENV['CXXFLAGS'] = '-Wall -O2'
+    ENV['LD'] = 'x86_64-w64-mingw32-ld'
+    ENV['LDFLAGS'] = '-L/usr/local/opt/mingw-w64-libressl/lib'
+    ENV['NM'] = 'x86_64-w64-mingw32-nm'
+    ENV['PATH'] = '/usr/local/bin:/usr/bin:/bin'
+    ENV['RANLIB'] = 'x86_64-w64-mingw32-ranlib'
+    ENV['STRIP'] = 'x86_64-w64-mingw32-strip'
+
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--host=x86_64-w64-mingw32",
+                          "--disable-debug-mode",
+                          "--disable-shared",
+                          "--disable-samples",
+                          "--disable-libevent-regress",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+end
+
+__END__
+--- a/configure.ac
++++ b/configure.ac
+@@ -342,6 +342,7 @@ AC_CHECK_FUNCS([ \
+   accept4 \
+   arc4random \
+   arc4random_buf \
++  arc4random_addrandom \
+   eventfd \
+   epoll_create1 \
+   fcntl \
+--- a/evutil_rand.c
++++ b/evutil_rand.c
+@@ -184,6 +184,24 @@ ev_arc4random_buf(void *buf, size_t n)
+ 	arc4random_buf(buf, n);
+ }
+ 
++/*
++ * The arc4random included in libevent implements arc4random_addrandom().
++ *
++ * OpenBSD libc/crypt/arc4random.c migrated to ChaCha20 since 1.25 and
++ * have removed arc4random_addrandom() since 1.26. Since then, other libcs
++ * followed suit (e.g. Android's own libc). But libevent's arc4random.c
++ * copy still implement arc4random_addrandom().
++ *
++ * See also:
++ *
++ * - https://github.com/measurement-kit/libevent/commit/8b275d967d7ffd95d5cc12069aef35669126c6d9
++ * - https://bugzilla.mozilla.org/show_bug.cgi?id=931354
++ * - https://bug931354.bmoattachments.org/attachment.cgi?id=829728
++ */
++#ifndef EVENT__HAVE_ARC4RANDOM_ADDRANDOM
++#define EVENT__HAVE_ARC4RANDOM_ADDRANDOM 1
++#endif
++
+ #endif /* } !EVENT__HAVE_ARC4RANDOM */
+ 
+ void
+@@ -195,8 +213,10 @@ evutil_secure_rng_get_bytes(void *buf, size_t n)
+ void
+ evutil_secure_rng_add_bytes(const char *buf, size_t n)
+ {
++#if defined EVENT__HAVE_ARC4RANDOM_ADDRANDOM
+ 	arc4random_addrandom((unsigned char*)buf,
+ 	    n>(size_t)INT_MAX ? INT_MAX : (int)n);
++#endif
+ }
+ 
+ void
+--- a/m4/libevent_openssl.m4
++++ b/m4/libevent_openssl.m4
+@@ -20,6 +20,7 @@ case "$enable_openssl" in
+ 	OPENSSL_INCS=`$PKG_CONFIG --cflags openssl 2>/dev/null`
+ 	;;
+     esac
++    have_openssl=yes  # Fix cross build issue found by @hellais and @sarath
+     case "$have_openssl" in
+      yes) ;;
+      *)
+--- a/openssl-compat.h
++++ b/openssl-compat.h
+@@ -1,8 +1,9 @@
+ #ifndef OPENSSL_COMPAT_H
+ #define OPENSSL_COMPAT_H
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined LIBRESSL_VERSION_NUMBER
+ 
++#if defined LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER < 0x2070000fL
+ static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
+ {
+ 	BIO_METHOD *biom = calloc(1, sizeof(BIO_METHOD));
+@@ -20,6 +21,7 @@ static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
+ #define BIO_meth_set_ctrl(b, f) (b)->ctrl = (f)
+ #define BIO_meth_set_create(b, f) (b)->create = (f)
+ #define BIO_meth_set_destroy(b, f) (b)->destroy = (f)
++#endif  /* LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER < 0x2070000fL */
+ 
+ #define BIO_set_init(b, val) (b)->init = (val)
+ #define BIO_set_data(b, val) (b)->ptr = (val)
+@@ -28,8 +30,10 @@ static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
+ #define BIO_get_data(b) (b)->ptr
+ #define BIO_get_shutdown(b) (b)->shutdown
+ 
++#if defined LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER < 0x2070000fL
+ #define TLS_method SSLv23_method
++#endif  /* LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER < 0x2070000fL */
+ 
+-#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
++#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L || defined LIBRESSL_VERSION_NUMBER */
+ 
+ #endif /* OPENSSL_COMPAT_H */
+

--- a/mingw-w64-libmaxminddb.rb
+++ b/mingw-w64-libmaxminddb.rb
@@ -1,0 +1,33 @@
+class MingwW64Libmaxminddb < Formula
+  desc "C library for the MaxMind DB file format"
+  homepage "https://github.com/maxmind/libmaxminddb"
+  url "https://github.com/maxmind/libmaxminddb/releases/download/1.3.2/libmaxminddb-1.3.2.tar.gz"
+  sha256 "e6f881aa6bd8cfa154a44d965450620df1f714c6dc9dd9971ad98f6e04f6c0f0"
+
+  depends_on "mingw-w64" => :build
+
+  keg_only :provided_by_macos  # Not very accurate
+
+  def install
+
+    ENV['AR'] = 'x86_64-w64-mingw32-ar'
+    ENV['AS'] = 'x86_64-w64-mingw32-as'
+    ENV['CC'] = 'x86_64-w64-mingw32-gcc'
+    ENV['CFLAGS'] = '-Wall -O2'
+    ENV['CPP'] = 'x86_64-w64-mingw32-cpp'
+    ENV['CXX'] = 'x86_64-w64-mingw32-g++'
+    ENV['CXXFLAGS'] = '-Wall -O2'
+    ENV['LD'] = 'x86_64-w64-mingw32-ld'
+    ENV['NM'] = 'x86_64-w64-mingw32-nm'
+    ENV['RANLIB'] = 'x86_64-w64-mingw32-ranlib'
+    ENV['STRIP'] = 'x86_64-w64-mingw32-strip'
+
+    system "./configure", "--disable-debug",
+                          "--host=x86_64-w64-mingw32",
+                          "--disable-dependency-tracking",
+                          "--disable-shared",
+                          "--disable-tests",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+end

--- a/mingw-w64-libressl.rb
+++ b/mingw-w64-libressl.rb
@@ -1,0 +1,36 @@
+class MingwW64Libressl < Formula
+  desc "Version of the SSL/TLS protocol forked from OpenSSL"
+  homepage "https://www.libressl.org/"
+  # Please ensure when updating version the release is from stable branch.
+  url "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.9.1.tar.gz"
+  mirror "https://mirrorservice.org/pub/OpenBSD/LibreSSL/libressl-2.9.1.tar.gz"
+  sha256 "39e4dd856694dc10d564201e4549c46d2431601a2b10f3422507e24ccc8f62f8"
+
+  depends_on "mingw-w64" => :build
+
+  keg_only :provided_by_macos  # Not very accurate
+
+  def install
+
+    ENV['AR'] = 'x86_64-w64-mingw32-ar'
+    ENV['AS'] = 'x86_64-w64-mingw32-as'
+    ENV['CC'] = 'x86_64-w64-mingw32-gcc'
+    ENV['CFLAGS'] = '-Wall -O2'
+    ENV['CPP'] = 'x86_64-w64-mingw32-cpp'
+    ENV['CXX'] = 'x86_64-w64-mingw32-g++'
+    ENV['CXXFLAGS'] = '-Wall -O2'
+    ENV['LD'] = 'x86_64-w64-mingw32-ld'
+    ENV['NM'] = 'x86_64-w64-mingw32-nm'
+    ENV['PATH'] = '/usr/local/bin:/usr/bin:/bin'
+    ENV['RANLIB'] = 'x86_64-w64-mingw32-ranlib'
+    ENV['STRIP'] = 'x86_64-w64-mingw32-strip'
+
+    system "./configure", "--host=x86_64-w64-mingw32",
+                          "--disable-dependency-tracking",
+                          "--disable-shared",
+                          "--prefix=#{prefix}",
+                          "--with-openssldir=#{etc}/libressl",
+                          "--sysconfdir=#{etc}/libressl"
+    system "make", "install"
+  end
+end

--- a/mingw-w64-measurement-kit.rb
+++ b/mingw-w64-measurement-kit.rb
@@ -1,0 +1,53 @@
+class MingwW64MeasurementKit < Formula
+  desc "Portable C++11 network measurement library"
+  homepage "https://measurement-kit.github.io/"
+  version "v0.10.3"
+  url "https://github.com/measurement-kit/measurement-kit/archive/v0.10.3.tar.gz"
+  sha256 "04bc1832fbaa54a9fde4923e8f44a2f99610a862c228dd05977c36f54870d80f"
+
+  depends_on "mingw-w64-libevent"
+  depends_on "mingw-w64-libmaxminddb"
+  depends_on "mingw-w64-curl"
+
+  depends_on "git" => :build
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  keg_only :provided_by_macos  # Not very accurate
+
+  def install
+
+    ENV['AR'] = 'x86_64-w64-mingw32-ar'
+    ENV['AS'] = 'x86_64-w64-mingw32-as'
+    ENV['CC'] = 'x86_64-w64-mingw32-gcc'
+    ENV['CPPFLAGS'] = '-Wall -O2 -Wno-cpp'
+    ENV['CFLAGS'] = '-Wall -O2'
+    ENV['CPP'] = 'x86_64-w64-mingw32-cpp'
+    ENV['CXX'] = 'x86_64-w64-mingw32-g++'
+    ENV['CXXFLAGS'] = '-Wall -O2'
+    ENV['LDFLAGS'] = '-static'
+    ENV['LD'] = 'x86_64-w64-mingw32-ld'
+    ENV['NM'] = 'x86_64-w64-mingw32-nm'
+    ENV['PATH'] = '/usr/local/bin:/usr/bin:/bin'
+    ENV['RANLIB'] = 'x86_64-w64-mingw32-ranlib'
+    ENV['STRIP'] = 'x86_64-w64-mingw32-strip'
+
+    # TODO(bassosimone): figure out why the measurement_kit binary built
+    # using this procedure isn't actually static. For reference, if we
+    # build go-measurement-kit for Windows using the library that we have
+    # compiled here, everything works and is actually static.
+
+    system "./autogen.sh", "-n"
+    system "./configure", "--prefix=#{prefix}",
+                          "--host=x86_64-w64-mingw32",
+                          "--disable-shared",
+                          "--disable-dependency-tracking",
+                          "--with-libevent=/usr/local/opt/mingw-w64-libevent",
+                          "--with-openssl=/usr/local/opt/mingw-w64-libressl",
+                          "--with-libcurl=/usr/local/opt/mingw-w64-curl",
+                          "--with-libmaxminddb=/usr/local/opt/mingw-w64-libmaxminddb"
+    system "make", "V=0"
+    system "make", "V=0", "install"
+  end
+end


### PR DESCRIPTION
This commit introduces new recipes for cross building MK, as a
library, and its dependencies, for building OONI for win64.

Limitations:

1. for now we're addressing only win64, which is anyway the kind
of build that we most likely want to have;

2. for unknown reasons, the `measurement_kit.exe` binary built
using this procedure is not statically linked, while, at the
same time, the libraries produced by this build are okay in my
system to obtain statically linked OONI binaries;

3. the reason I'm using in the keg-only is not very accurate.

I'll stop here, because this is already a great simplification
over the existing situation, and because my original goal was
to make the OONI build easier for us for Windows systems.

I'll open bugs for the above limitations.

While there, I've also improve measurement-kit.rb.